### PR TITLE
Add Case Study filter to project index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ node_modules/
 .next/
 out/
 next-env.d.ts
+
+# TypeScript incremental build cache
+tsconfig.tsbuildinfo

--- a/app/work/case-studies/page.tsx
+++ b/app/work/case-studies/page.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { caseStudyMeta, caseStudyProjects } from "@/lib/projects";
+import ProjectIndex from "@/components/ProjectIndex";
+
+export const metadata: Metadata = {
+  title: `${caseStudyMeta.title} — Jordan`,
+  description: caseStudyMeta.blurb,
+};
+
+export default function CaseStudiesPage() {
+  const count = caseStudyProjects().length;
+
+  return (
+    <section className="stage work">
+      <Link href="/work/" className="cs__back">
+        ← All Work
+      </Link>
+
+      <div className="cs__eyebrow">
+        <span>↳ Deep dives</span>
+        <span className="cat">
+          {count} case stud{count === 1 ? "y" : "ies"}
+        </span>
+      </div>
+      <h1 className="cs__title">
+        Case <span className="out">Studies</span>
+      </h1>
+      <p className="cs__lede">{caseStudyMeta.blurb}</p>
+
+      <ProjectIndex initial="Case Study" linked />
+    </section>
+  );
+}

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { projects, CATEGORIES, categoryMeta } from "@/lib/projects";
+import { projects, CATEGORIES, categoryMeta, caseStudyMeta } from "@/lib/projects";
 import ProjectIndex from "@/components/ProjectIndex";
 
 export const metadata: Metadata = {
@@ -35,6 +35,7 @@ export default function WorkIndex() {
             {c}
           </Link>
         ))}
+        <Link href={`/work/${caseStudyMeta.slug}/`}>{caseStudyMeta.title}</Link>
       </div>
 
       <ProjectIndex initial="All" linked />

--- a/components/ProjectIndex.tsx
+++ b/components/ProjectIndex.tsx
@@ -6,14 +6,18 @@ import {
   projects,
   CATEGORIES,
   categoryMeta,
+  caseStudyMeta,
+  CASE_STUDY_FILTER,
   type Category,
   type Project,
 } from "@/lib/projects";
 
-type Filter = Category | "All";
+type Filter = Category | "All" | typeof CASE_STUDY_FILTER;
 
 function hrefFor(f: Filter): string {
-  return f === "All" ? "/work/" : `/work/category/${categoryMeta[f].slug}/`;
+  if (f === "All") return "/work/";
+  if (f === CASE_STUDY_FILTER) return `/work/${caseStudyMeta.slug}/`;
+  return `/work/category/${categoryMeta[f].slug}/`;
 }
 
 /**
@@ -34,22 +38,23 @@ export default function ProjectIndex({
   const active: Filter = linked ? initial : filter;
 
   const counts = useMemo(() => {
-    const c: Record<string, number> = { All: projects.length };
+    const c: Record<string, number> = {
+      All: projects.length,
+      [CASE_STUDY_FILTER]: projects.filter((p) => p.caseStudy).length,
+    };
     CATEGORIES.forEach((cat) => {
       c[cat] = projects.filter((p) => p.categories.includes(cat)).length;
     });
     return c;
   }, []);
 
-  const visible = useMemo(
-    () =>
-      active === "All"
-        ? projects
-        : projects.filter((p) => p.categories.includes(active as Category)),
-    [active],
-  );
+  const visible = useMemo(() => {
+    if (active === "All") return projects;
+    if (active === CASE_STUDY_FILTER) return projects.filter((p) => p.caseStudy);
+    return projects.filter((p) => p.categories.includes(active as Category));
+  }, [active]);
 
-  const filters = ["All", ...CATEGORIES] as Filter[];
+  const filters = ["All", ...CATEGORIES, CASE_STUDY_FILTER] as Filter[];
 
   return (
     <>

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -52,6 +52,20 @@ export function projectsByCategory(cat: Category): Project[] {
   return projects.filter((p) => p.categories.includes(cat));
 }
 
+/** Label used by the "Case Study" filter chip; not a real Category. */
+export const CASE_STUDY_FILTER = "Case Study" as const;
+
+export const caseStudyMeta = {
+  slug: "case-studies",
+  title: "Case Studies",
+  blurb:
+    "Deep-dive write-ups on selected builds: the architecture decisions, the trade-offs, and how each system was deployed, demoed, and destroyed.",
+};
+
+export function caseStudyProjects(): Project[] {
+  return projects.filter((p) => p.caseStudy);
+}
+
 export const projects: Project[] = [
   {
     num: "01",


### PR DESCRIPTION
## Summary
Adds a **Case Study** filter chip to the project index, isolating the 5 projects that have a dedicated deep-dive page. The live index had ALL / AWS / AZURE / AI / PLATFORM but no way to surface just the case studies, which are the strongest pieces.

## Changes
- **`lib/projects.ts`** — `CASE_STUDY_FILTER`, `caseStudyMeta` (slug `case-studies` + blurb), and `caseStudyProjects()` helper. Case studies are derived from the existing `caseStudy` field, so nothing is tagged twice.
- **`components/ProjectIndex.tsx`** — chip appears in both modes: client-side toggle on the homepage, real link on route pages. Placed last in the row since it's a cross-cutting axis, not a tech category.
- **`app/work/case-studies/page.tsx`** — new shareable static route at `/work/case-studies/`, mirroring the category pages.
- **`app/work/page.tsx`** — matching quick-nav link.
- **`.gitignore`** — ignore `tsconfig.tsbuildinfo`.

## Verification
- `npx tsc --noEmit` clean
- `npm run build` succeeds; `/work/case-studies` exported as static (17 pages total)