### PR TITLE
Add CLAUDE.md with no-attribution convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# Repo conventions
+
+## Git / attribution
+- Do NOT add a `Co-Authored-By: Claude` (or any Claude/Anthropic) trailer to commit messages in this repo.
+- Do NOT add a "Generated with Claude Code" footer (or any Claude/Anthropic attribution) to PR descriptions.
+- Keep commit messages and PR bodies free of tooling attribution.


### PR DESCRIPTION
Adds a CLAUDE.md instructing future Claude Code sessions in this repo to omit Co-Authored-By trailers on commits and the "Generated with Claude Code" footer on PR descriptions.