### PR TITLE
Professional refresh: Focus capabilities section, curated Selected Work tier, cert pipeline

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -944,13 +944,83 @@ section {
   color: var(--text-dim);
 }
 
+/* Capabilities */
+.caps {
+  padding-bottom: 120px;
+}
+.caps__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1px;
+  background: var(--border);
+  box-shadow: 0 0 0 1px var(--border);
+}
+.cap {
+  background: var(--bg);
+  padding: 36px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-height: 280px;
+  transition: background 0.4s var(--ease);
+}
+.cap:hover {
+  background: var(--surface);
+}
+.cap__num {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  color: var(--text-dim);
+}
+.cap__title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 28px;
+  letter-spacing: -0.005em;
+  line-height: 1.1;
+  color: var(--white);
+}
+.cap__blurb {
+  font-size: 14px;
+  line-height: 1.65;
+  color: var(--text-secondary);
+  max-width: 52ch;
+}
+.cap__proofs {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  padding-top: 16px;
+}
+.cap__proof {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text);
+  text-decoration: none;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 2px;
+  transition: color 0.3s var(--ease), border-color 0.3s var(--ease);
+}
+.cap__proof:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.cap__proof .arrow {
+  color: var(--text-dim);
+}
+
 /* Certs */
 .certs {
   padding-bottom: 120px;
 }
 .certs__grid {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(3, 1fr);
   gap: 1px;
   background: var(--border);
   box-shadow: 0 0 0 1px var(--border);
@@ -1010,6 +1080,10 @@ section {
 }
 .cert__status.expired .dot {
   background: var(--text-dim);
+}
+.cert__status.progress .dot {
+  background: transparent;
+  box-shadow: inset 0 0 0 1.5px var(--accent-bright);
 }
 .cert__bottom {
   margin-top: auto;
@@ -1706,6 +1780,19 @@ section {
   }
   .skills__group .items span {
     font-size: 17px;
+  }
+  .caps {
+    padding-bottom: 64px;
+  }
+  .caps__grid {
+    grid-template-columns: 1fr;
+  }
+  .cap {
+    padding: 24px;
+    min-height: 0;
+  }
+  .cap__title {
+    font-size: 22px;
   }
   .certs {
     padding-bottom: 64px;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import Hero from "@/components/Hero";
 import Marquee from "@/components/Marquee";
 import About from "@/components/About";
+import Capabilities from "@/components/Capabilities";
 import Experience from "@/components/Experience";
 import Projects from "@/components/Projects";
 import Skills from "@/components/Skills";
@@ -13,6 +14,7 @@ export default function Home() {
       <Hero />
       <Marquee />
       <About />
+      <Capabilities />
       <Experience />
       <Projects />
       <Skills />

--- a/components/Capabilities.tsx
+++ b/components/Capabilities.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link";
+import { capabilities } from "@/lib/site";
+
+export default function Capabilities() {
+  return (
+    <section id="capabilities" className="stage caps">
+      <div className="sec-head reveal">
+        <span className="sec-head__num">/02</span>
+        <h2 className="sec-head__title">Focus</h2>
+        <span className="sec-head__meta">
+          Core capabilities
+          <br />
+          Proven in production
+        </span>
+      </div>
+      <div className="caps__grid reveal">
+        {capabilities.map((c) => (
+          <div className="cap" key={c.num}>
+            <div className="cap__num">/{c.num}</div>
+            <h3 className="cap__title">{c.title}</h3>
+            <p className="cap__blurb">{c.blurb}</p>
+            <div className="cap__proofs">
+              {c.proofs.map((p) =>
+                p.internal ? (
+                  <Link className="cap__proof" key={p.label} href={p.href}>
+                    {p.label} <span className="arrow">→</span>
+                  </Link>
+                ) : (
+                  <a
+                    className="cap__proof"
+                    key={p.label}
+                    href={p.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {p.label} <span className="arrow">↗</span>
+                  </a>
+                ),
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/Certs.tsx
+++ b/components/Certs.tsx
@@ -4,7 +4,7 @@ export default function Certs() {
   return (
     <section id="certs" className="stage certs">
       <div className="sec-head reveal">
-        <span className="sec-head__num">/05</span>
+        <span className="sec-head__num">/06</span>
         <h2 className="sec-head__title">Certified</h2>
         <span className="sec-head__meta">
           Credentials
@@ -21,7 +21,7 @@ export default function Certs() {
                 <span className="sub">{c.sub}</span>
               </div>
               <span
-                className={`cert__status${c.status === "Expired" ? " expired" : ""}`}
+                className={`cert__status${c.status === "Expired" ? " expired" : ""}${c.status === "In Progress" ? " progress" : ""}`}
               >
                 <span className="dot" />
                 {c.status}

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -4,7 +4,7 @@ export default function Contact() {
   return (
     <section id="contact" className="stage contact">
       <div className="sec-head reveal">
-        <span className="sec-head__num">/06</span>
+        <span className="sec-head__num">/07</span>
         <h2 className="sec-head__title">Signal</h2>
         <span className="sec-head__meta">
           Channels

--- a/components/Experience.tsx
+++ b/components/Experience.tsx
@@ -4,7 +4,7 @@ export default function Experience() {
   return (
     <section id="experience" className="stage exp">
       <div className="sec-head reveal">
-        <span className="sec-head__num">/02</span>
+        <span className="sec-head__num">/03</span>
         <h2 className="sec-head__title">Work</h2>
         <span className="sec-head__meta">
           Selected positions

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -7,10 +7,11 @@ import Logo from "./Logo";
 
 const LINKS = [
   { num: "01", label: "About", target: "about" },
-  { num: "02", label: "Work", target: "experience" },
-  { num: "03", label: "Index", target: "projects" },
-  { num: "04", label: "Stack", target: "skills" },
-  { num: "05", label: "Signal", target: "contact" },
+  { num: "02", label: "Focus", target: "capabilities" },
+  { num: "03", label: "Work", target: "experience" },
+  { num: "04", label: "Index", target: "projects" },
+  { num: "05", label: "Stack", target: "skills" },
+  { num: "06", label: "Signal", target: "contact" },
 ];
 
 export default function Nav() {

--- a/components/ProjectIndex.tsx
+++ b/components/ProjectIndex.tsx
@@ -21,17 +21,20 @@ function hrefFor(f: Filter): string {
 }
 
 /**
- * Shared project index used in two modes:
- * - interactive (homepage): chips toggle a client-side filter.
+ * Shared project index used in three modes:
+ * - featured (homepage): curated Selected Work tier, no filter chips.
+ * - interactive: chips toggle a client-side filter.
  * - linked (route pages): chips are real links to /work/category/<cat>, and the
  *   visible filter is fixed by the page's `initial` prop so the page is shareable.
  */
 export default function ProjectIndex({
   initial = "All",
   linked = false,
+  featuredOnly = false,
 }: {
   initial?: Filter;
   linked?: boolean;
+  featuredOnly?: boolean;
 }) {
   const [filter, setFilter] = useState<Filter>(initial);
   const [modal, setModal] = useState<Project | null>(null);
@@ -49,15 +52,17 @@ export default function ProjectIndex({
   }, []);
 
   const visible = useMemo(() => {
+    if (featuredOnly) return projects.filter((p) => p.featured);
     if (active === "All") return projects;
     if (active === CASE_STUDY_FILTER) return projects.filter((p) => p.caseStudy);
     return projects.filter((p) => p.categories.includes(active as Category));
-  }, [active]);
+  }, [active, featuredOnly]);
 
   const filters = ["All", ...CATEGORIES, CASE_STUDY_FILTER] as Filter[];
 
   return (
     <>
+      {!featuredOnly && (
       <div className="proj__filters reveal">
         {filters.map((f) =>
           linked ? (
@@ -79,6 +84,7 @@ export default function ProjectIndex({
           ),
         )}
       </div>
+      )}
 
       <div className="proj__list reveal">
         {visible.map((p) =>

--- a/components/Projects.tsx
+++ b/components/Projects.tsx
@@ -1,25 +1,25 @@
 import Link from "next/link";
-import { projects } from "@/lib/projects";
+import { projects, featuredProjects } from "@/lib/projects";
 import ProjectIndex from "./ProjectIndex";
 
 export default function Projects() {
   return (
     <section id="projects" className="stage proj">
       <div className="sec-head reveal">
-        <span className="sec-head__num">/03</span>
-        <h2 className="sec-head__title">Index</h2>
+        <span className="sec-head__num">/04</span>
+        <h2 className="sec-head__title">Selected Work</h2>
         <span className="sec-head__meta">
-          Selected works
+          Curated builds
           <br />
-          {projects.length} indexed
+          {featuredProjects().length} of {projects.length} indexed
         </span>
       </div>
 
-      <ProjectIndex initial="All" />
+      <ProjectIndex featuredOnly />
 
       <div className="proj__more reveal">
         <Link href="/work/" className="btn btn--ghost">
-          Open Full Index <span className="arrow">→</span>
+          Open Full Index ({projects.length}) <span className="arrow">→</span>
         </Link>
       </div>
     </section>

--- a/components/Skills.tsx
+++ b/components/Skills.tsx
@@ -4,7 +4,7 @@ export default function Skills() {
   return (
     <section id="skills" className="stage skills">
       <div className="sec-head reveal">
-        <span className="sec-head__num">/04</span>
+        <span className="sec-head__num">/05</span>
         <h2 className="sec-head__title">Stack</h2>
         <span className="sec-head__meta">
           Tools &amp; languages

--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -10,6 +10,8 @@ export interface Project {
   link: string;
   /** present when this project has a dedicated deep case-study page */
   caseStudy?: string;
+  /** curated into the homepage Selected Work tier */
+  featured?: boolean;
 }
 
 export const CATEGORIES: Category[] = ["AWS", "Azure", "AI", "Platform"];
@@ -66,6 +68,10 @@ export function caseStudyProjects(): Project[] {
   return projects.filter((p) => p.caseStudy);
 }
 
+export function featuredProjects(): Project[] {
+  return projects.filter((p) => p.featured);
+}
+
 export const projects: Project[] = [
   {
     num: "01",
@@ -75,6 +81,7 @@ export const projects: Project[] = [
     tags: ["Lambda", "Cost Explorer", "DynamoDB", "API Gateway", "CloudFront", "React", "EventBridge Scheduler", "Terraform"],
     categories: ["AWS"],
     link: "https://github.com/jordann6/aws-cost-intelligence-dashboard",
+    featured: true,
     caseStudy: "cost-intelligence-dashboard",
   },
   {
@@ -85,6 +92,7 @@ export const projects: Project[] = [
     tags: ["Lambda", "API Gateway", "DynamoDB", "Anthropic SDK", "Terraform", "Python", "IAM", "Secrets Manager"],
     categories: ["AWS", "AI"],
     link: "https://github.com/jordann6/multi-agent-coding-orchestrator",
+    featured: true,
     caseStudy: "multi-agent-coding-orchestrator",
   },
   {
@@ -96,6 +104,7 @@ export const projects: Project[] = [
     categories: ["AWS", "Platform"],
     caseStudy: "multi-region-failover",
     link: "https://github.com/jordann6/multi-region-failover-manager",
+    featured: true,
   },
   {
     num: "04",
@@ -105,6 +114,7 @@ export const projects: Project[] = [
     tags: ["Azure Functions", "Cosmos DB", "React", "C# .NET 8", "Static Web Apps", "Terraform"],
     categories: ["Azure"],
     link: "https://github.com/jordann6/azure-finops-dashboard",
+    featured: true,
   },
   {
     num: "05",
@@ -132,6 +142,7 @@ export const projects: Project[] = [
     tags: ["GuardDuty", "OpenSearch", "Falco", "OPA Gatekeeper", "EventBridge", "Lambda", "Pacu", "Terraform"],
     categories: ["AWS", "Platform"],
     link: "https://github.com/jordann6/cloud-security-lab",
+    featured: true,
     caseStudy: "cloud-security-lab",
   },
   {
@@ -259,6 +270,7 @@ export const projects: Project[] = [
     tags: ["EKS", "ArgoCD", "Crossplane", "Kyverno", "Backstage", "IRSA", "Terraform", "GitOps"],
     categories: ["AWS", "Platform"],
     link: "https://github.com/jordann6/aws-developer-platform",
+    featured: true,
     caseStudy: "aws-developer-platform",
   },
   {
@@ -279,6 +291,7 @@ export const projects: Project[] = [
     tags: ["Management Groups", "Azure Policy", "Hub-Spoke", "VNet Peering", "Terraform", "Governance"],
     categories: ["Azure", "Platform"],
     link: "https://github.com/jordann6/azure-landing-zone",
+    featured: true,
   },
   {
     num: "24",
@@ -361,5 +374,6 @@ export const projects: Project[] = [
     tags: ["AWS Organizations", "SCPs", "IAM Identity Center", "CloudTrail", "KMS", "S3 Object Lock", "AWS Budgets", "Terraform"],
     categories: ["AWS", "Platform"],
     link: "https://github.com/jordann6/landing-zone-automator",
+    featured: true,
   },
 ];

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -51,12 +51,74 @@ export interface Cert {
   sub: string;
   name: string;
   provider: string;
-  status: "Active" | "Expired";
+  status: "Active" | "Expired" | "In Progress";
 }
 
 export const certs: Cert[] = [
   { sigil: "AWS", sub: "SAA—C03", name: "Solutions Architect Associate", provider: "Amazon Web Services", status: "Active" },
+  { sigil: "AWS", sub: "SCS—C02", name: "Security Specialty", provider: "Amazon Web Services", status: "In Progress" },
   { sigil: "AZ", sub: "—104", name: "Azure Administrator Associate", provider: "Microsoft Azure", status: "Expired" },
+];
+
+export interface CapabilityProof {
+  label: string;
+  href: string;
+  /** internal case-study routes render with next/link */
+  internal?: boolean;
+}
+
+export interface Capability {
+  num: string;
+  title: string;
+  blurb: string;
+  proofs: CapabilityProof[];
+}
+
+export const capabilities: Capability[] = [
+  {
+    num: "A",
+    title: "Cloud Foundations & Governance",
+    blurb:
+      "Multi-account and multi-subscription foundations built in Terraform: OU and management group hierarchies, SCP and Azure Policy guardrails, hub-spoke networking, account vending, and centralized audit logging.",
+    proofs: [
+      { label: "AWS Landing Zone Automator", href: "https://github.com/jordann6/landing-zone-automator" },
+      { label: "Azure Landing Zone", href: "https://github.com/jordann6/azure-landing-zone" },
+      { label: "AWS SCP Governance", href: "https://github.com/jordann6/aws-scp-governance" },
+    ],
+  },
+  {
+    num: "B",
+    title: "FinOps & Cost Engineering",
+    blurb:
+      "Cost visibility built as software on both clouds: anomaly detection against rolling baselines, spend forecasting, tagging compliance for attribution, and scale-to-zero patterns that keep idle cost near nothing.",
+    proofs: [
+      { label: "Cost Intelligence Dashboard", href: "/work/cost-intelligence-dashboard/", internal: true },
+      { label: "Azure FinOps Dashboard", href: "https://github.com/jordann6/azure-finops-dashboard" },
+      { label: "LLM Gateway Cost Routing", href: "https://github.com/jordann6/llm-gateway" },
+    ],
+  },
+  {
+    num: "C",
+    title: "Resilience & Incident Response",
+    blurb:
+      "Systems that answer failure without a human in the hot path: cross-region failover with automated database promotion, alarm-driven remediation, and AI-assisted incident runbooks, all verified against live cloud breakage.",
+    proofs: [
+      { label: "Multi-Region Failover Manager", href: "/work/multi-region-failover/", internal: true },
+      { label: "AWS Incident Responder", href: "/work/aws-incident-responder/", internal: true },
+      { label: "Azure Event-Driven Remediation", href: "https://github.com/jordann6/azure-event-driven-remediation" },
+    ],
+  },
+  {
+    num: "D",
+    title: "Platform & DevSecOps",
+    blurb:
+      "Paved roads on Kubernetes across both clouds: GitOps reconciliation, self-service infrastructure APIs, admission policy, and CI/CD pipelines gated on SAST, container scanning, and DAST before anything deploys.",
+    proofs: [
+      { label: "AWS Developer Platform", href: "/work/aws-developer-platform/", internal: true },
+      { label: "Cloud Security Lab", href: "/work/cloud-security-lab/", internal: true },
+      { label: "Azure DevSecOps Pipeline", href: "https://github.com/jordann6/azure-devsecops-project" },
+    ],
+  },
 ];
 
 export const marqueeItems = [


### PR DESCRIPTION
## What changed

### New /02 Focus section
Four capability pillars on the homepage, each with a blurb and three proof links (case studies link internally, other builds go to GitHub):
- Cloud Foundations & Governance (AWS Landing Zone Automator, Azure Landing Zone, SCP Governance)
- FinOps & Cost Engineering (Cost Intelligence, Azure FinOps, LLM Gateway)
- Resilience & Incident Response (Multi-Region Failover, AWS Incident Responder, Azure Event-Driven Remediation)
- Platform & DevSecOps (AWS Developer Platform, Cloud Security Lab, Azure DevSecOps Pipeline)

### Curated Selected Work tier
The homepage index now shows 8 featured projects (via `featured: true` in `lib/projects.ts`) with no filter chips, plus an Open Full Index (32) button. The full filterable catalog at /work is unchanged.

### Certs
Three cards: SAA (Active), SCS-C02 Security Specialty (new In Progress status with hollow accent dot), AZ-104 (kept Expired). Grid moved to three columns.

### Structure
Sections renumbered /01 through /07, nav gains a Focus link, ProjectIndex gains a `featuredOnly` mode.

## Verification
- `npm run build` static export passes
- Exported HTML checked: 4 pillar cards and 12 proof links on home, 8 featured items with no chips, 32 projects with chips at /work, 3 cert cards, section numbering through /07